### PR TITLE
Added support for using old big picture mode

### DIFF
--- a/usr/bin/steam-de
+++ b/usr/bin/steam-de
@@ -93,7 +93,8 @@ if settings["on_deck"] in (True, "on", "yes"):
 if settings["deck_ui_mode"] in (True, "on", "yes"):
     _COMMANDS["start_steam"].append("-gamepadui")
     _COMMANDS["start_steam"].append("-steampal")
-
+else
+    _COMMANDS["start_steam"].append("-oldbigpicture")
 
 # Define all the functions we will need
 def is_steam_running():

--- a/usr/bin/steam-de
+++ b/usr/bin/steam-de
@@ -90,8 +90,7 @@ if settings["steam_os_mode"] in (True, "on", "yes"):
 if settings["on_deck"] in (True, "on", "yes"):
     _COMMANDS["start_steam"].append("-steamdeck")
 
-if settings["deck_ui_mode"] in (True, "on", "yes"):
-else
+if settings["deck_ui_mode"] in (False, "off", "no", "disable"):
     _COMMANDS["start_steam"].append("-oldbigpicture")
 
 # Define all the functions we will need

--- a/usr/bin/steam-de
+++ b/usr/bin/steam-de
@@ -91,8 +91,6 @@ if settings["on_deck"] in (True, "on", "yes"):
     _COMMANDS["start_steam"].append("-steamdeck")
 
 if settings["deck_ui_mode"] in (True, "on", "yes"):
-    _COMMANDS["start_steam"].append("-gamepadui")
-    _COMMANDS["start_steam"].append("-steampal")
 else
     _COMMANDS["start_steam"].append("-oldbigpicture")
 


### PR DESCRIPTION
Quoting from [Steam](https://store.steampowered.com/news/app/593110/view/3682291055854286778):
> Big Picture Mode
>
>&nbsp;   New Big Picture Mode has been made the default experience. For compatibility purposes, old Big Picture can be accessed by using the command-line option "-oldbigpicture". Note that this functionality will be removed in a future update.

